### PR TITLE
Add option to cache token

### DIFF
--- a/examples/save-token.php
+++ b/examples/save-token.php
@@ -17,7 +17,7 @@ $httpClient = new Client([
     'handler' => HandlerStack::create(),
 ]);
 
-$identidyService = SwauthService::factory($httpClient);
+$identityService = SwauthService::factory($httpClient);
 $options = [
     'authUrl' => $base_uri,
     'username' => 'test:tester',
@@ -26,7 +26,7 @@ $options = [
 ];
 
 $openstack = new OpenStack($options);
-$token = $identidyService->generateToken($openstackOptions);
+$token = $identityService->generateToken($options);
 
 // Display token expiry
 echo sprintf('Token expires at %s' . PHP_EOL, $token->expires->format('c'));

--- a/examples/save-token.php
+++ b/examples/save-token.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Based on https://php-opencloudopenstack.readthedocs.io/en/latest/services/identity/v3/tokens.html?#generate-token-and-persist-to-file
+ */
+require 'vendor/autoload.php';
+
+use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
+use OpenStack\Common\Transport\Utils as TransportUtils;
+use OpenStack\OpenStack;
+use Recras\OpenStack\Identity\Swauth\Service as SwauthService;
+
+$base_uri = 'http://127.0.0.1:8090/';
+
+$httpClient = new Client([
+    'base_uri' => TransportUtils::normalizeUrl($base_uri),
+    'handler' => HandlerStack::create(),
+]);
+
+$identidyService = SwauthService::factory($httpClient);
+$options = [
+    'authUrl' => $base_uri,
+    'username' => 'test:tester',
+    'key' => 'testing',
+    'identityService' => $identityService,
+];
+
+$openstack = new OpenStack($options);
+$token = $identidyService->generateToken($openstackOptions);
+
+// Display token expiry
+echo sprintf('Token expires at %s' . PHP_EOL, $token->expires->format('c'));
+
+// Save token to file
+file_put_contents('token.json', json_encode($token->export()));

--- a/examples/use-saved-token.php
+++ b/examples/use-saved-token.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Based on https://php-opencloudopenstack.readthedocs.io/en/latest/services/identity/v3/tokens.html?#initialize-open-stack-using-cached-authentication-token
+ */
+require 'vendor/autoload.php';
+
+use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
+use OpenStack\Common\Transport\Utils as TransportUtils;
+use OpenStack\OpenStack;
+use Recras\OpenStack\Identity\Swauth\Service as SwauthService;
+
+$base_uri = 'http://127.0.0.1:8090/';
+
+$httpClient = new Client([
+    'base_uri' => TransportUtils::normalizeUrl($base_uri),
+    'handler' => HandlerStack::create(),
+]);
+
+$identidyService = SwauthService::factory($httpClient);
+$options = [
+    'authUrl' => $base_uri,
+    'username' => 'test:tester',
+    'key' => 'testing',
+    'identityService' => $identityService,
+];
+
+$token = json_decode(file_get_contents('token.json'), true);
+
+// Inject cached token to params if token is still fresh
+if ((new \DateTimeImmutable($token['expires'])) > (new \DateTimeImmutable('now'))) {
+    $options['cachedToken'] = $token;
+}
+
+$openstack = new OpenStack($options);

--- a/examples/use-saved-token.php
+++ b/examples/use-saved-token.php
@@ -17,7 +17,7 @@ $httpClient = new Client([
     'handler' => HandlerStack::create(),
 ]);
 
-$identidyService = SwauthService::factory($httpClient);
+$identityService = SwauthService::factory($httpClient);
 $options = [
     'authUrl' => $base_uri,
     'username' => 'test:tester',

--- a/src/Identity/Swauth/Models/ServiceCatalog.php
+++ b/src/Identity/Swauth/Models/ServiceCatalog.php
@@ -19,7 +19,8 @@ class ServiceCatalog extends OperatorResource implements Catalog
     }
     public function populateFromArray(array $data): self
     {
-        throw new BadMethodCallException(self::class . '::populateFromArray: not implemented');
+        $this->base_uri = $data['base_uri'];
+        return $this;
     }
 
     public function populateFromResponse(ResponseInterface $resp): self
@@ -27,5 +28,11 @@ class ServiceCatalog extends OperatorResource implements Catalog
         $this->base_uri = $resp->getHeaderLine('X-Storage-Url');
         return $this;
     }
-}
 
+    public function export(): array
+    {
+        return [
+            'base_uri' => $this->base_uri,
+        ];
+    }
+}

--- a/src/Identity/Swauth/Models/Token.php
+++ b/src/Identity/Swauth/Models/Token.php
@@ -4,6 +4,7 @@ namespace Recras\OpenStack\Identity\Swauth\Models;
 
 use OpenStack\Common\Resource\OperatorResource;
 use Psr\Http\Message\ResponseInterface;
+use Recras\OpenStack\Identity\Swauth\Models\ServiceCatalog;
 
 class Token extends OperatorResource implements \OpenStack\Common\Auth\Token
 {
@@ -11,8 +12,8 @@ class Token extends OperatorResource implements \OpenStack\Common\Auth\Token
     const TOKEN_EXPIRES_HEADER = 'X-Auth-Token-Expires';
 
     public $id;
-
     public $expires;
+    public $catalog;
 
     public function getId(): string
     {
@@ -26,7 +27,11 @@ class Token extends OperatorResource implements \OpenStack\Common\Auth\Token
 
     public function populateFromArray(array $data): self
     {
-        throw new BadMethodCallException(self::class . '::populateFromArray: not implemented');
+        $this->id = $data['id'];
+        $this->expires = new \DateTimeImmutable($data['expires']);
+        $this->catalog = $this->model(ServiceCatalog::class, $data['catalog']);
+
+        return $this;
     }
 
     public function populateFromResponse(ResponseInterface $response): self
@@ -34,7 +39,17 @@ class Token extends OperatorResource implements \OpenStack\Common\Auth\Token
         $this->id = $response->getHeaderLine(self::TOKEN_HEADER);
         $expires_seconds = $response->getHeaderLine(self::TOKEN_EXPIRES_HEADER);
         $this->expires = (new \DateTimeImmutable)->add(new \DateInterval('PT' . $expires_seconds . 'S'));
+        $this->catalog = $this->model(ServiceCatalog::class, $response);
 
         return $this;
+    }
+
+    public function export(): array
+    {
+        return [
+            'id' => $this->id,
+            'expires' => $this->expires->format('c'),
+            'catalog' => $this->catalog->export(),
+        ];
     }
 }

--- a/src/Identity/Swauth/Models/Token.php
+++ b/src/Identity/Swauth/Models/Token.php
@@ -44,6 +44,13 @@ class Token extends OperatorResource implements \OpenStack\Common\Auth\Token
         return $this;
     }
 
+    /**
+     * Returns a serialized representation of an authentication token.
+     *
+     * Initialize OpenStack object using $params['cachedToken'] to reduce the amount of HTTP calls.
+     *
+     * @return array
+     */
     public function export(): array
     {
         return [


### PR DESCRIPTION
Without caching a new token will be generated for every request, which can get quite slow.